### PR TITLE
Update renovate.json configuration for improved dependency management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
   "rangeStrategy": "bump",
   "rebaseWhen": "behind-base-branch",
   "ignoreUnstable": true,
-  "stabilityDays": 3,
+  "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
 
   "enabledManagers": ["npm", "github-actions"],
@@ -33,7 +33,7 @@
 
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["every saturday"],
+    "schedule": ["on saturday"],
     "automerge": true
   },
 
@@ -44,7 +44,7 @@
       "separateMinorPatch": false,
       "automerge": true,
       "platformAutomerge": true,
-      "requiredStatusChecks": null
+      "ignoreTests": true
     },
     {
       "description": "Automerge only devDeps minor/patch",
@@ -75,9 +75,9 @@
     },
     {
       "description": "Slow down @types packages",
-      "matchPackagePatterns": ["^@types/"],
-      "schedule": ["every 2 weeks"],
-      "groupName": "Type definitions"
+      "schedule": ["before 3am on monday"],
+      "groupName": "Type definitions",
+      "matchPackageNames": ["/^@types//"]
     }
   ],
 


### PR DESCRIPTION
- Changed stabilityDays to minimumReleaseAge for better clarity.
- Updated lock file maintenance schedule to "on saturday".
- Modified automerge settings to ignore tests for certain PRs.
- Adjusted schedule for @types packages to run before 3am on Monday.